### PR TITLE
Feat/4

### DIFF
--- a/app/api/documents.py
+++ b/app/api/documents.py
@@ -1,6 +1,9 @@
-from fastapi import APIRouter, File, UploadFile, HTTPException, status
-from app.schemas.document_schema import DocumentUploadResponse
-from app.services.file_service import save_uploaded_file
+from fastapi import APIRouter, File, UploadFile, HTTPException, status, BackgroundTasks
+from pathlib import Path
+
+from app.schemas.document_schema import DocumentUploadResponse, ConvertRequest, ConvertResponse
+from app.services.file_service import save_uploaded_file, STORAGE_DIR
+from app.services.convert_service import process_conversion
 
 router = APIRouter(
     prefix="/documents",
@@ -34,3 +37,19 @@ async def upload_document(file: UploadFile = File(...)):
         fileName=file.filename,
         status="UPLOADED"
     )
+
+@router.post("/{document_id}/convert", response_model=ConvertResponse, status_code=status.HTTP_202_ACCEPTED)
+async def convert_document(document_id: str, request: ConvertRequest, background_tasks: BackgroundTasks):
+    doc_dir = STORAGE_DIR / document_id
+    pdf_path = doc_dir / "original.pdf"
+    meta_path = doc_dir / "meta.json"
+
+    # 1. 문서 및 파일 존재 여부 검증
+    if not doc_dir.exists() or not pdf_path.exists() or not meta_path.exists():
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Document not found")
+
+    # 2. 백그라운드 변환 작업 큐잉
+    background_tasks.add_task(process_conversion, document_id, request.format)
+
+    # 3. 비동기 처리 응답 (PROCESSING & 202 Accepted) 반환
+    return ConvertResponse(documentId=document_id, status="PROCESSING")

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,0 +1,10 @@
+import os
+
+class Settings:
+    # 환경변수에서 AI 서버 주소를 가져오며, 없을 경우 기본값 세팅
+    AI_SERVER_URL: str = os.getenv("AI_SERVER_URL", "http://localhost:8001/ai/convert")
+    
+    # AI 요청 Timeout (기본 5분 = 300초 설정)
+    REQUEST_TIMEOUT: int = int(os.getenv("REQUEST_TIMEOUT", "300"))
+
+settings = Settings()

--- a/app/core/enums.py
+++ b/app/core/enums.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+class MarkdownFormat(str, Enum):
+    COMMONMARK = "commonmark"
+    GFM = "gfm"
+    MARKDOWN = "markdown"

--- a/app/schemas/document_schema.py
+++ b/app/schemas/document_schema.py
@@ -1,6 +1,14 @@
 from pydantic import BaseModel
+from app.core.enums import MarkdownFormat
 
 class DocumentUploadResponse(BaseModel):
     documentId: str
     fileName: str
+    status: str
+
+class ConvertRequest(BaseModel):
+    format: MarkdownFormat
+
+class ConvertResponse(BaseModel):
+    documentId: str
     status: str

--- a/app/services/convert_service.py
+++ b/app/services/convert_service.py
@@ -1,0 +1,97 @@
+import json
+import logging
+from pathlib import Path
+import requests
+
+from app.core.enums import MarkdownFormat
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+# 파일 서비스와 동일한 스토리지 경로 사용
+STORAGE_DIR = Path("storage/documents")
+
+def process_conversion(document_id: str, target_format: MarkdownFormat):
+    doc_dir = STORAGE_DIR / document_id
+    meta_path = doc_dir / "meta.json"
+    pdf_path = doc_dir / "original.pdf"
+
+    # 1. 검증 (API 레벨에서도 했지만 2차 확인)
+    if not doc_dir.exists() or not meta_path.exists() or not pdf_path.exists():
+        logger.error(f"Missing required files for document_id: {document_id}")
+        return
+
+    # 2. 상태를 PROCESSING으로 변경
+    try:
+        with open(meta_path, "r", encoding="utf-8") as f:
+            meta_data = json.load(f)
+            
+        meta_data["status"] = "PROCESSING"
+        
+        # 이전 실패 에러가 있다면 삭제
+        if "errorMessage" in meta_data:
+            del meta_data["errorMessage"]
+            
+        with open(meta_path, "w", encoding="utf-8") as f:
+            json.dump(meta_data, f, ensure_ascii=False, indent=2)
+    except Exception as e:
+        logger.error(f"Failed to update meta.json to PROCESSING for {document_id}: {e}")
+        return
+
+    # 3. AI 서버로 변환 요청
+    try:
+        with open(pdf_path, "rb") as pdf_file:
+            # multipart/form-data
+            files_payload = {"file": ("original.pdf", pdf_file, "application/pdf")}
+            data_payload = {"format": target_format.value}
+            
+            response = requests.post(
+                settings.AI_SERVER_URL,
+                files=files_payload,
+                data=data_payload,
+                timeout=settings.REQUEST_TIMEOUT
+            )
+            
+        # HTTP 에러 시 예외 발생
+        response.raise_for_status()
+        
+        # 4. AI 응답 처리
+        result_data = response.json()
+        markdown_content = result_data.get("markdown", "")
+        images = result_data.get("images", [])
+
+        # Markdown 파일 저장
+        md_path = doc_dir / "original_markdown.md"
+        with open(md_path, "w", encoding="utf-8") as md_file:
+            md_file.write(markdown_content)
+            
+        # 이미지 저장
+        if images:
+            images_dir = doc_dir / "images"
+            images_dir.mkdir(parents=True, exist_ok=True)
+            for idx, img in enumerate(images):
+                # 이 부분은 AI 서버 실제 이미지 반환 포맷에 맞춰 추후 구현
+                pass
+
+        # 5. 상태를 SUCCESS로 업데이트
+        meta_data["status"] = "SUCCESS"
+        meta_data["format"] = target_format.value
+        with open(meta_path, "w", encoding="utf-8") as f:
+            json.dump(meta_data, f, ensure_ascii=False, indent=2)
+            
+    except requests.exceptions.Timeout:
+        _handle_conversion_failure(meta_path, meta_data, "Timeout while connecting to AI server")
+    except requests.exceptions.RequestException as e:
+        _handle_conversion_failure(meta_path, meta_data, f"AI server request failed: {str(e)}")
+    except Exception as e:
+        _handle_conversion_failure(meta_path, meta_data, f"Internal error during conversion: {str(e)}")
+
+def _handle_conversion_failure(meta_path: Path, meta_data: dict, error_message: str):
+    logger.error(f"Conversion failed: {error_message}")
+    meta_data["status"] = "FAILED"
+    meta_data["errorMessage"] = error_message
+    try:
+        with open(meta_path, "w", encoding="utf-8") as f:
+            json.dump(meta_data, f, ensure_ascii=False, indent=2)
+    except Exception as e:
+        logger.error(f"Failed to write error state to meta.json: {e}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ uvloop==0.22.1
 watchfiles==1.1.1
 websockets==16.0
 python-multipart==0.0.22
+requests

--- a/test_api_flow.py
+++ b/test_api_flow.py
@@ -1,0 +1,51 @@
+import subprocess
+import time
+import requests
+import json
+import io
+import sys
+from pathlib import Path
+
+def run_test():
+    print("🚀 테스트용 FastAPI 서버를 시작합니다...")
+    server = subprocess.Popen([sys.executable, "-m", "uvicorn", "app.main:app", "--port", "8008"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    time.sleep(2) # 서버가 뜰 때까지 대기
+    
+    try:
+        base_url = "http://localhost:8008"
+        
+        print("\n[1] 더미 PDF 파일 업로드 중...")
+        dummy_pdf = io.BytesIO(b"%PDF-1.4 dummy test pdf content")
+        res1 = requests.post(f"{base_url}/documents/upload", files={"file": ("test.pdf", dummy_pdf, "application/pdf")})
+        res1.raise_for_status()
+        doc_id = res1.json()["documentId"]
+        print(f"✅ 업로드 성공! documentId: {doc_id}")
+        
+        print(f"\n[2] Markdown 변환 요청 (format: gfm)...")
+        res2 = requests.post(f"{base_url}/documents/{doc_id}/convert", json={"format": "gfm"})
+        res2.raise_for_status()
+        print(f"✅ 변환 요청 수락됨! (202 Accepted) | 응답값: {res2.json()}")
+        
+        print("\n[3] 백그라운드 태스크 처리 결과 확인 (meta.json 읽기)...")
+        meta_path = Path(f"storage/documents/{doc_id}/meta.json")
+        for _ in range(10):
+            time.sleep(0.5)
+            with open(meta_path, "r", encoding="utf-8") as f:
+                meta = json.load(f)
+            if meta.get("status") in ["SUCCESS", "FAILED"]:
+                print(f"✅ 백그라운드 처리 완료! 최종 상태: {meta.get('status')}")
+                if "errorMessage" in meta:
+                     print(f"   👉 메타데이터 내 Error 메세지: {meta.get('errorMessage')}")
+                break
+        else:
+            print("⏳ 백그라운드 작업이 너무 오래 걸립니다.")
+            
+    except Exception as e:
+        print(f"❌ 에러 발생: {e}")
+    finally:
+        print("\n🛑 테스트 서버를 종료합니다...")
+        server.terminate()
+        server.wait()
+
+if __name__ == "__main__":
+    run_test()


### PR DESCRIPTION
## 📌 작업 요약
PDF → Markdown 변환 요청 API (`POST /documents/{documentId}/convert`)를 구현함.
변환 포맷 정책이 아직 미확정인 점을 고려하여, 포맷 목록을 Enum으로 중앙 관리하고 향후 변경에도 최소 수정으로 대응 가능한 구조로 설계함.

## 📌 구현 기능 (변경 사항)
- `POST /documents/{documentId}/convert` 엔드포인트 추가 (응답 코드: **202 Accepted**)
- 지원 변환 포맷(`commonmark`, `gfm`, `markdown`)을 Enum으로 중앙 관리
- AI 서버 URL 및 요청 Timeout을 설정으로 분리
- AI 서버 호출 및 변환 로직을 백그라운드 태스크로 처리
- 변환 실패 시 `meta.json`에 `errorMessage` 기록
- 변환 요청/응답 Pydantic 스키마 추가

## 🧐 구현 방식 & 이유

**포맷 관리 Enum 분리**
- 포맷 문자열을 하드코딩하는 대신 Enum으로 관리
- Pydantic과 자동 연동되어 유효하지 않은 포맷 값은 422 에러로 자동 차단
- 포맷 추가/변경/삭제 시 Enum 한 곳만 수정하면 전체에 자동 반영

**설정 분리**
- `AI_SERVER_URL`과 `REQUEST_TIMEOUT`을 환경변수 기반으로 주입받아 배포 환경별 유연한 설정 가능

**비동기 백그라운드 처리 (FastAPI `BackgroundTasks`)**
- PDF 변환은 AI 서버 I/O가 포함되어 시간이 걸릴 수 있으므로, 즉시 `202 Accepted + PROCESSING` 상태를 반환하고 변환 작업은 백그라운드에서 수행
- 예외 발생 시 `FAILED` 상태와 `errorMessage`를 `meta.json`에 기록

## 🔗 관련 이슈
- #4 
## ✅ 체크리스트
- [x] 코딩 컨벤션에 맞게 코드를 작성했나요?
- [x] 관련된 기능에 버그가 없는지 직접 테스트했나요?
- [x] 불필요한 콘솔 로그(`console.log`)나 주석을 제거했나요?
## 📝 추가 필요 작업
- AI 서버 구현 완료 후 실제 변환 결과 E2E 테스트 필요
- 이미지 응답 포맷 확정 후 이미지 저장 로직 완성 필요
- 환경별 설정 가이드 추가 필요