### PR TITLE
Feat/8

### DIFF
--- a/app/api/documents.py
+++ b/app/api/documents.py
@@ -1,9 +1,10 @@
 from fastapi import APIRouter, File, UploadFile, HTTPException, status, BackgroundTasks
 from pathlib import Path
 
-from app.schemas.document_schema import DocumentUploadResponse, ConvertRequest, ConvertResponse, DocumentStatusResponse
+from app.schemas.document_schema import DocumentUploadResponse, ConvertRequest, ConvertResponse, DocumentStatusResponse, ResultResponse
 from app.services.file_service import save_uploaded_file, get_document_meta, STORAGE_DIR
 from app.services.convert_service import process_conversion
+from app.services.result_service import get_document_result
 
 router = APIRouter(
     prefix="/documents",
@@ -74,3 +75,9 @@ async def get_document_status(document_id: str):
         format=meta.get("format"),
         errorMessage=meta.get("errorMessage"),
     )
+
+@router.get("/{document_id}/result", response_model=ResultResponse)
+async def get_document_result_api(document_id: str):
+    # 파일 읽기 로직은 service 계층에 위임
+    result = get_document_result(document_id)
+    return ResultResponse(**result)

--- a/app/schemas/document_schema.py
+++ b/app/schemas/document_schema.py
@@ -20,3 +20,10 @@ class DocumentStatusResponse(BaseModel):
     status: str  # UPLOADED | PROCESSING | SUCCESS | FAILED
     format: Optional[str] = None
     errorMessage: Optional[str] = None
+
+class ResultResponse(BaseModel):
+    documentId: str
+    status: str
+    format: Optional[str] = None
+    markdown: str
+    images: list[str]

--- a/app/services/result_service.py
+++ b/app/services/result_service.py
@@ -1,0 +1,65 @@
+import json
+from pathlib import Path
+from fastapi import HTTPException, status
+
+from app.services.file_service import STORAGE_DIR
+
+
+def get_document_result(document_id: str) -> dict:
+    """변환 결과를 읽어 딕셔너리로 반환한다."""
+    doc_dir: Path = STORAGE_DIR / document_id
+
+    # 1. documentId 폴더 존재 확인
+    if not doc_dir.exists():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Document not found"
+        )
+
+    # 2. meta.json 존재 확인 및 읽기
+    meta_path = doc_dir / "meta.json"
+    if not meta_path.exists():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="meta.json not found"
+        )
+
+    try:
+        with open(meta_path, "r", encoding="utf-8") as f:
+            meta = json.load(f)
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to read meta.json"
+        )
+
+    # 3. original_markdown.md 존재 확인 및 읽기
+    markdown_path = doc_dir / "original_markdown.md"
+    if not markdown_path.exists():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Markdown result not found"
+        )
+
+    try:
+        with open(markdown_path, "r", encoding="utf-8") as f:
+            markdown_content = f.read()
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to read markdown file"
+        )
+
+    # 4. images/ 폴더 내 파일명 목록 수집
+    images_dir = doc_dir / "images"
+    images: list[str] = []
+    if images_dir.exists() and images_dir.is_dir():
+        images = [f.name for f in sorted(images_dir.iterdir()) if f.is_file()]
+
+    return {
+        "documentId": meta.get("documentId", document_id),
+        "status": meta.get("status", ""),
+        "format": meta.get("format"),
+        "markdown": markdown_content,
+        "images": images,
+    }


### PR DESCRIPTION
## 📌 작업 요약

변환 결과 조회 API(GET /documents/{documentId}/result)를 구현함.
변환 완료된 문서의 마크다운 내용 및 이미지 목록을 클라이언트가 조회할 수 있도록 meta.json 및 변환 결과 파일 기반 반환 구조로 설계함.

## 📌 구현 기능 (변경 사항)

- `GET /documents/{documentId}/result` 엔드포인트 추가 (응답 코드: **200 OK**)
- documentId, status, format, markdown, images 필드 반환
- [ResultResponse] Pydantic 스키마 추가
- [get_document_result()] 서비스 함수 분리

## 🧐 구현 방식 & 이유

**파일 기반 결과 조회**
- 변환 결과는 meta.json 및 original_markdown.md에 저장되므로, 별도 DB 없이 파일 읽기만으로 결과 반환 가능
- 폴더 미존재 시 404, meta.json 미존재 시 404, 마크다운 파일 미존재 시 404, 파일 읽기 실패 시 500으로 명확히 구분

**이미지 목록 확장성 고려**
- images 필드는 현재 파일명 목록(`list[str]`)으로 반환하되, 이후 URL 포함 구조로 확장 용이하도록 단순 리스트 유지

**서비스 레이어 분리**
- [get_document_result()] 함수를 별도 서비스 파일로 분리하여 API 라우터에서 I/O 로직 제거

## 🔗 관련 이슈

- #8

## ✅ 체크리스트

- [x] 코딩 컨벤션에 맞게 코드를 작성했나요?
- [x] 관련된 기능에 버그가 없는지 직접 테스트했나요?
- [x] 불필요한 콘솔 로그나 주석을 제거했나요?

## 📝 추가 필요 작업

- FE 결과 페이지와 result API 연동 필요
- 이미지 파일 URL 반환 기능 추가 필요 (정적 파일 서빙 연동)
