### PR TITLE
Feat/10

### DIFF
--- a/app/api/documents.py
+++ b/app/api/documents.py
@@ -1,10 +1,11 @@
 from fastapi import APIRouter, File, UploadFile, HTTPException, status, BackgroundTasks
 from pathlib import Path
 
-from app.schemas.document_schema import DocumentUploadResponse, ConvertRequest, ConvertResponse, DocumentStatusResponse, ResultResponse
+from app.schemas.document_schema import DocumentUploadResponse, ConvertRequest, ConvertResponse, DocumentStatusResponse, ResultResponse, MarkdownSaveRequest, MarkdownSaveResponse
 from app.services.file_service import save_uploaded_file, get_document_meta, STORAGE_DIR
 from app.services.convert_service import process_conversion
 from app.services.result_service import get_document_result
+from app.services.markdown_service import save_markdown
 
 router = APIRouter(
     prefix="/documents",
@@ -81,3 +82,13 @@ async def get_document_result_api(document_id: str):
     # 파일 읽기 로직은 service 계층에 위임
     result = get_document_result(document_id)
     return ResultResponse(**result)
+
+@router.put("/{document_id}/markdown", response_model=MarkdownSaveResponse)
+async def update_document_markdown(document_id: str, request: MarkdownSaveRequest):
+    # Markdown 파일 수정 저장 및 meta 정보 업데이트 로직은 Service에 위임
+    save_markdown(document_id, request.markdown)
+    return MarkdownSaveResponse(
+        documentId=document_id,
+        status="SAVED"
+    )
+

--- a/app/schemas/document_schema.py
+++ b/app/schemas/document_schema.py
@@ -27,3 +27,10 @@ class ResultResponse(BaseModel):
     format: Optional[str] = None
     markdown: str
     images: list[str]
+
+class MarkdownSaveRequest(BaseModel):
+    markdown: str
+
+class MarkdownSaveResponse(BaseModel):
+    documentId: str
+    status: str

--- a/app/services/markdown_service.py
+++ b/app/services/markdown_service.py
@@ -1,0 +1,46 @@
+import json
+from pathlib import Path
+from fastapi import HTTPException, status
+
+from app.services.file_service import STORAGE_DIR
+
+def save_markdown(document_id: str, markdown: str) -> None:
+    """사용자가 수정한 Markdown을 저장하고 meta.json을 업데이트한다."""
+    doc_dir: Path = STORAGE_DIR / document_id
+
+    # 1. documentId 폴더 존재 확인
+    if not doc_dir.exists() or not doc_dir.is_dir():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Document not found"
+        )
+
+    # meta.json 존재 여부 확인
+    meta_path = doc_dir / "meta.json"
+    if not meta_path.exists():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="meta.json not found"
+        )
+
+    try:
+        # 2. edited_markdown.md에 내용 저장 (빈 문자열도 허용됨)
+        edited_markdown_path = doc_dir / "edited_markdown.md"
+        with open(edited_markdown_path, "w", encoding="utf-8") as f:
+            f.write(markdown)
+
+        # 3. meta.json 읽기 및 업데이트
+        with open(meta_path, "r", encoding="utf-8") as f:
+            meta = json.load(f)
+
+        # edited 필드를 True로 추가하거나 업데이트
+        meta["edited"] = True
+
+        with open(meta_path, "w", encoding="utf-8") as f:
+            json.dump(meta, f, ensure_ascii=False, indent=2)
+
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to save markdown file or update document metadata"
+        )


### PR DESCRIPTION
## 📌 작업 요약

사용자 웹 수정본 저장 API(PUT /documents/{documentId}/markdown)를 구현함.
결과 페이지에서 사용자가 수정한 마크다운을 서버의 `edited_markdown.md`에 저장하고, 파일의 메타데이터(`meta.json`)를 안전하게 업데이트하는 구조로 설계함.

## 📌 구현 기능 (변경 사항)

- `PUT /documents/{documentId}/markdown` 엔드포인트 추가 (응답 코드: **200 OK**)
- [MarkdownSaveRequest] 및 [MarkdownSaveResponse] Pydantic 스키마 추가
- [save_markdown()] 서비스 함수 분리 및 생성
- 빈 문자열("") 마크다운 저장도 허용함

## 🧐 구현 방식 & 이유

**확실한 리소스 검증**
- 파일 시스템 기반 모델 특성상 documentId를 포함하는 폴더 및 `meta.json`이 존재하는지 선행적으로 확인하고, 없다면 **404 Not Found** 에러를 반환해 예측할 수 없는 I/O 문제를 방지함.

**효율적인 메타데이터 관리**
- 수동 파일 제어를 하므로 수정본이 전송되었을 때 `edited_markdown.md`를 덮어쓰거나 생성함과 동시에, `meta.json` 내 `edited` 필드를 `true`로 업데이트 시켜 다른 API나 서비스에서 수정 여부를 쉽게 식별하도록 함.

**서비스 레이어 분리**
- [save_markdown()] 함수를 별도 서비스 파일(`markdown_service.py`)로 분리하여 API 라우팅 레이어에서는 I/O 로직 없이 비즈니스 로직만 호출하도록 간결하게 분리함.

## 🔗 관련 이슈

- #10

## ✅ 체크리스트

- [x] 코딩 컨벤션에 맞게 코드를 작성했나요?
- [x] 관련된 기능에 버그가 없는지 직접 테스트했나요?
- [x] 불필요한 콘솔 로그나 주석을 제거했나요?

## 📝 추가 필요 작업

- FE 결과 페이지와 markdown PUT API 연동 진행 필요
- 연동 중 발생하는 CORS 또는 저장 동기화 안정성 점검 필요
